### PR TITLE
quattor.build.xml: fix handling of cluster.pan.dep.ignore

### DIFF
--- a/quattor.build.xml
+++ b/quattor.build.xml
@@ -341,7 +341,7 @@
           maxIteration="5000" debugTask="${compile.debug.task}" formats="${pan.formats}"
           outputDir="${outputdir}" includeroot="${cfg}" includes="${cluster.pan.includes}"
           logging="${pan.logging}"
-          logfile="${pan.logfile}" ignoreDependencyPattern="${pan.dep.ignore}"
+          logfile="${pan.logfile}" ignoreDependencyPattern="${cluster.pan.dep.ignore}"
     	  debugNsInclude="${pan.debug.include}" debugNsExclude="${pan.debug.exclude}">
 
       <!-- The load path and profiles to compile. -->


### PR DESCRIPTION
In the past months, it was added the possibility to take into account all the templates under `repository/` namespace, normally ignored with SPMA to avoid unnecessary recompile of profiles. Unfortunately a typo broke this new feature!
