### PR TITLE
Add panc-version target to ant: displays pan compiler version

### DIFF
--- a/quattor.build.xml
+++ b/quattor.build.xml
@@ -440,4 +440,11 @@
   </target>
 
 
+  <!-- Show pan compiler version -->
+  <target name="panc.version" depends="init,define.tasks" description="Display pan compiler version">
+
+    <panc-version />
+
+  </target>
+
 </project>


### PR DESCRIPTION
Requires https://github.com/quattor/pan/pull/75 to be merged first.

Would be good to merge before https://github.com/quattor/pan/issues/74.
