### PR TITLE
create-vanilla-SCDB: ensure that bash is used

### DIFF
--- a/utils/scdb/create-vanilla-SCDB.sh
+++ b/utils/scdb/create-vanilla-SCDB.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # This script creates a vanilla SCDB from GitHub site, with both
 # SCDB itself and the template library. The cluster examples are then compiled.
 #


### PR DESCRIPTION
(required for this script to work on some Debian derivatives)