### PR TITLE
create-vanilla-SCDB: remove signalling of invalid options

### DIFF
--- a/utils/scdb/create-vanilla-SCDB.sh
+++ b/utils/scdb/create-vanilla-SCDB.sh
@@ -125,9 +125,6 @@ do
     then
       tl_download_args="${tl_download_args} $2"
       shift
-    else
-      echo "Invalid option ($1). Aborting..."
-      usage
     fi
     ;;
   esac


### PR DESCRIPTION
Options unknown by create-vanilla-SCDB must be passed to get-template-library which will report invalid ones. The check (a left-over according to comment) prevents the new --continous-integration to be passed successfully.