### PR TITLE
Deprecation warnings during the compilation phase controled by pan.warnings

### DIFF
--- a/quattor.build.xml
+++ b/quattor.build.xml
@@ -337,7 +337,7 @@
               includes="${cluster.current} ${cluster.current}/profiles ${cluster.current}/site" />
     </path>
 
-    <panc verbose="true" warnings="off" checkDependencies="true"
+    <panc verbose="true" warnings="${pan.warnings}" checkDependencies="true"
           maxIteration="5000" debugTask="${compile.debug.task}" formats="${pan.formats}"
           outputDir="${outputdir}" includeroot="${cfg}" includes="${cluster.pan.includes}"
           logging="${pan.logging}"


### PR DESCRIPTION
- Used to be the case only during the syntax-check phase, preventing display
  of deprecated() calls
- On by default: define pan.warnings property to off to disable

Required by https://github.com/quattor/template-library-core/pull/154 to get the deprecation warning displayed.